### PR TITLE
Added concatenation of multiple uploaded images to single PDF functionality (Issue #23)

### DIFF
--- a/app/bookShelf/books/JSONcreator.py
+++ b/app/bookShelf/books/JSONcreator.py
@@ -82,6 +82,9 @@ def generate_path(path):
                 continue
             d[x]=new_path
     else:
+        # Do not include meta files in the heirarchy when recreating it.
+        if path.split('.')[-1]=='meta':
+            return ''
         ## TODO: MORE ROBUST PATH CONFIGURATION
         return path[2:]
     return d

--- a/app/bookShelf/books/static/js/browse.js
+++ b/app/bookShelf/books/static/js/browse.js
@@ -88,7 +88,18 @@ function get_event_handler_col(is_file,path_prefix,url)
     if(is_file)
     {
         // return function(){var win = window.open(url,'_blank');win.focus();};
-        return function(){var win = window.open(url);win.focus();};
+        // return function(){var win = window.open(url);win.focus();};
+        return function(event)
+        {
+            // prevent opening of a new tab/window of Citadel when using Ctrl+Click or 
+            // Shift+Click to open the file in new tab/window
+            if(event.ctrlKey || event.shiftKey || event.metaKey) //might find a better way to implement this
+            {
+                event.preventDefault();
+            }
+            var win = window.open(url);
+            win.focus();
+        };
     }
     else
     {

--- a/app/bookShelf/books/static/js/upload.js
+++ b/app/bookShelf/books/static/js/upload.js
@@ -27,6 +27,21 @@ $(document).ready(function() {
 				for (var i = 0; i < fileDump.files.length; i++) {
 					addTagBox(fileDump.files[i].name,default_tags)
 				}
+
+				var img_files = [];
+				var IMG_EXT = ['jpg', 'jpeg', 'png', 'gif']
+				//check if multiple image files have been uploaded to concatenate them.
+				for(var i = 0; i< fileDump.files.length; i++){
+					var file_name=fileDump.files[i].name;
+					var ext = file_name.split(".").pop();
+					if(IMG_EXT.includes(ext)){
+						img_files.push(fileDump.files[i]);
+					}
+				}
+				if(img_files.length>1){
+					addImageReorderBox(img_files)
+				}
+
 				var buttons = document.getElementsByClassName("submit-btn");
 				for(var j=0;j<buttons.length;j++){
 					buttons[j].parentNode.removeChild(buttons[j]);	
@@ -54,8 +69,89 @@ function addTagBox(name,tags){
 	tagInput(fileBox)
 }
 
+function addImageReorderBox(files){
+	document.getElementById('reorder-section').innerHTML="<div class='reorder-section-heading'>"+
+		"<strong>You have uploaded more than one image files. Please select the order of the pages in these images</strong>"+
+		"</div>";
+	for(var i=0; i<files.length; i++){
+		var preview = document.createElement('div');
+		preview.setAttribute('class', 'image-preview');
+		preview.setAttribute('style', 'display: inline-block; margin: 1em;')
+		document.getElementById('reorder-section').appendChild(preview);
+
+		var img = document.createElement('img')
+		img.setAttribute('src', URL.createObjectURL(files[i]));
+		img.setAttribute('height', '100px');
+		img.setAttribute('width', '100px');
+		img.setAttribute('alt', files[i].name);
+		preview.appendChild(img);
+
+		var input = document.createElement('select')
+		input.setAttribute('type', 'text');
+		input.setAttribute('name', i+1);
+		input.setAttribute('class', 'reorder-dropdown');
+		input.setAttribute('style', 'display: flex; margin: 0 auto;')
+		for(var j=1; j<=files.length; j++){
+			var option = document.createElement('option');
+			option.setAttribute('value', j);
+			option.innerHTML = j;
+			if(j==i+1)
+			    option.setAttribute('selected', '');
+			input.appendChild(option);
+		}
+		preview.appendChild(input);
+	}
+}
+
+function getImageOrder(){
+	var imageOrder = [];
+	if(document.getElementById('reorder-section').children.length>0){
+		var imgOrder = document.getElementsByClassName('image-preview');
+		for(var i=0; i<imgOrder.length; i++){
+			var value = imgOrder[i].getElementsByTagName('select')[0].value;
+			imageOrder.push(value);
+		}
+	}
+	return imageOrder;
+}
+
+//function to check the validity of the page number order of the images selected by the user 
+function isValidOrder(order){
+	var valid = true;
+	if(order.length==0){
+		return valid;
+	}
+	for(var i=0; i<order.length-1; i++){
+		if(order[i]<1 || order[i]>order.length){
+			valid = false;
+			break;
+		}
+		for(var j=i+1; j<order.length; j++){
+			if(order[i]==order[j]){
+				valid = false;
+				break;
+			}
+		}
+		if(!valid){
+			break;
+		}
+	}
+
+	var orderBox = document.getElementsByClassName('image-preview')[0].getElementsByTagName('select')[0];
+	if(valid){
+		orderBox.setCustomValidity("");
+	}
+	else{
+		orderBox.setCustomValidity("Page numbering not unique or out of bounds. Please enter valid page numbers");
+	}
+
+	return orderBox.checkValidity()
+}
+
 function submit_data(){
-	if(isValid()){
+	var imageOrder = getImageOrder();
+
+	if(isValid() && isValidOrder(imageOrder)){
 		var tagBoxes = document.getElementsByClassName('tagbox')
 		var tagList=[]
 		for (var i = 0; i < tagBoxes.length; i++) {
@@ -73,6 +169,19 @@ function submit_data(){
 
 		hiddenInput.setAttribute("type", "hidden")
 		hiddenInput.setAttribute("name", "tag-string")
+
+		
+		var imageOrderString = ''
+		if(imageOrder.length>0)
+			imageOrderString = imageOrder.join(TAG_SUB_LIST_SEPARATOR); 
+		var imageOrderInput = document.createElement("input")
+		imageOrderInput.value=imageOrderString;
+
+		imageOrderInput.setAttribute("type", "hidden");
+		imageOrderInput.setAttribute("name", "image-order")
+		
+
+		document.getElementById("upload-form").appendChild(imageOrderInput)
 		document.getElementById("upload-form").appendChild(hiddenInput)
 		document.getElementById("upload-form").submit()
 	}

--- a/app/bookShelf/books/templates/books/shelf.html
+++ b/app/bookShelf/books/templates/books/shelf.html
@@ -1,4 +1,4 @@
-{% load static from staticfiles%}
+{% load static from staticfiles %}
 {% load extra_tags %}
 
 <!doctype html>

--- a/app/bookShelf/books/templates/books/upload.html
+++ b/app/bookShelf/books/templates/books/upload.html
@@ -83,6 +83,8 @@ NOTE: You can upload multiple files of the same type, like multiple lectures, no
         <div class="form-group row" >
             <button id="next-btn" class="btn btn-outline-primary col-sm-6 upload-btn" >Next</button>            
         </div>
+        
+        <div id="reorder-section"></div>
 
         <div id="tags-section"></div>
         <div class="form-group row" id="submit-row"></div>

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -7,6 +7,7 @@ django-crontab==0.7.1
 djangorestframework==3.9.1
 gunicorn==19.9.0
 idna==2.10
+pillow==8.3.1
 psycopg2-binary==2.7.5
 pycparser==2.20
 PyJWT==1.7.1


### PR DESCRIPTION
Implemented #23 

Pillow library is used to handle images.

- Single image uploaded converted to PDF
- Multiple images uploaded are concatenated and converted to a single PDF
- When mixed format files are uploaded(eg. PDF and images) PDFs are unaltered and all images are concatenated to a single PDF
- When multiple images are uploaded, the uploader is given an additional option (mandatory) to give ordering of images.

Currently supported image formats included are: jpg, jpeg, gif, png. 
tiff, bmp, webp and other formats supported by pillow are currently excluded but can be included by appending 'IMG_EXT' array in upload.js and views.py